### PR TITLE
read the file with the line feed code crlf

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -176,9 +176,11 @@ func getFileHead(path string) ([]string, error) {
 	lines := []string{}
 
 	defer fp.Close()
-	reader := bufio.NewReaderSize(fp, 4096)
-	for line := ""; err == nil; line, err = reader.ReadString('\n') {
-		lines = append(lines, line)
+	scanner := bufio.NewScanner(fp)
+	buf := make([]byte, 0, 1024*4)
+	scanner.Buffer(buf, 1024*8)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
 		cnt++
 		if cnt > 10 {
 			break

--- a/cli.go
+++ b/cli.go
@@ -24,6 +24,11 @@ const (
 	ExitCodeError int = 1 + iota
 )
 
+const (
+	initScanTokenSize int = 1024 * 4
+	MaxScanTokenSize  int = 1024 * 64
+)
+
 // CLI is the command line object
 type CLI struct {
 	// outStream and errStream are the stdout and stderr
@@ -177,8 +182,8 @@ func getFileHead(path string) ([]string, error) {
 
 	defer fp.Close()
 	scanner := bufio.NewScanner(fp)
-	buf := make([]byte, 0, 1024*4)
-	scanner.Buffer(buf, 1024*8)
+	buf := make([]byte, 0, initScanTokenSize)
+	scanner.Buffer(buf, MaxScanTokenSize)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 		cnt++


### PR DESCRIPTION
In case line code is crlf files, `getFileHead` returns `[]`.
So I used scanner to read the crlf file.

### current

```go
lines, err := getFileHead(filePath)
fmt.Println(lines) // => []
```

### pr

```go
lines, err := getFileHead(filePath)
fmt.Println(lines) // => [`file lines`]
```

Thank you for your wonderful product 🎉 

