### PR TITLE
skip empty files if received any responses

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -150,6 +150,10 @@ func request(url string, timeout int, insecure bool, filePath string, skipErrors
 		return err
 	}
 
+	if len(lines) == 0 && r.ContentLength > 0 {
+		return nil
+	}
+
 	for _, l := range lines {
 		if strings.Index(string(body), l) < 0 {
 			return nil


### PR DESCRIPTION
空のファイルがあると`strings.Index`に空文字が渡って必ずマッチしてしまいます。ローカルファイルが空でかつサーバからのレスポンスが存在した場合には、中身のチェックをする前にreturnするようにしてみました。