### PR TITLE
Fix the handling for empty files

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -150,7 +150,7 @@ func request(url string, timeout int, insecure bool, filePath string, skipErrors
 		return err
 	}
 
-	if len(lines) == 0 && r.ContentLength > 0 {
+	if len(lines) == 0 && len(body) > 0 {
 		return nil
 	}
 


### PR DESCRIPTION
In Go's `net/http`, unless you specify `DisableCompression` in `Transport`, `Accept-Encoding: gzip` is automatically added, which results in the inability to infer `ContentLength`, consistently setting it to `-1`.
(ref: https://github.com/golang/go/blob/master/src/net/http/transport.go#L202)

In the previous implementation shown below, `r.ContentLength > 0` always evaluates to `False`, rendering it meaningless.

```go
if len(lines) == 0 && r.ContentLength > 0 {
    return nil
}
```

Since setting `DisableCompression` is expected to affect performance, I modified it to compare with `len(body)` to match the intended condition.
